### PR TITLE
Bump to 2.60.8-0.7.2

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -303,6 +303,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 		// Gas is free, but no refunds!
 		st.initialGas = st.msg.Gas()
 		st.gasRemaining += st.msg.Gas() // Add gas here in order to be able to execute calls.
+		st.evm.BlobFee = new(uint256.Int)
 		// Don't touch the gas pool for system transactions
 		if st.msg.IsSystemTx() {
 			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context.Time) {

--- a/params/version.go
+++ b/params/version.go
@@ -44,7 +44,7 @@ const (
 const (
 	OPVersionMajor    = 0          // Major version component of the current release
 	OPVersionMinor    = 7          // Minor version component of the current release
-	OPVersionMicro    = 1          // Patch version component of the current release
+	OPVersionMicro    = 2          // Patch version component of the current release
 	OPVersionModifier = "unstable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
https://github.com/testinprod-io/op-erigon/releases/tag/2.60.8-0.7.2